### PR TITLE
Feature/03 micropost backend

### DIFF
--- a/app/controllers/api/microposts_controller.rb
+++ b/app/controllers/api/microposts_controller.rb
@@ -1,0 +1,32 @@
+class Api::MicropostsController < ApiController
+  # ログインしたユーザーのみ操作させたいため
+  before_action :authenticate, only: [:create]
+
+  def create
+    micropost = current_user.microposts.create!(micropost_params)
+    if micropost.save
+      render json: micropost, serializer: MicropostSerializer
+    else
+      error_message = { error: { messages: [ "Content can't be blank" ] } }
+      render json: error_message, status: 422
+    end
+  end
+
+  def show
+  end
+
+  def index
+  end
+
+  def update
+  end
+
+  def destroy
+  end
+
+  private
+    def micropost_params
+      # 想定しているパラメータのみを受け取る
+      params.require(:micropost).permit(:content)
+    end
+end

--- a/app/controllers/api/microposts_controller.rb
+++ b/app/controllers/api/microposts_controller.rb
@@ -2,6 +2,13 @@ class Api::MicropostsController < ApiController
   # ログインしたユーザーのみ操作させたいため
   before_action :authenticate, only: [:create]
 
+  def index
+    # N+1問題を避けるためにincludesを使用する
+    microposts = Micropost.includes(:user).order(created_at: :desc)
+    # 対象がコレクションの場合はeach_serializerを使用する
+    render json: microposts, each_serializer: MicropostSerializer
+  end
+
   def create
     micropost = current_user.microposts.create!(micropost_params)
     if micropost.save
@@ -22,8 +29,6 @@ class Api::MicropostsController < ApiController
     end
   end
 
-  def index
-  end
 
   def update
   end

--- a/app/controllers/api/microposts_controller.rb
+++ b/app/controllers/api/microposts_controller.rb
@@ -10,6 +10,8 @@ class Api::MicropostsController < ApiController
   end
 
   def create
+    # current_userはUser.findの結果を返すので、
+    # modelでhas_manyを指定しているmicropostsを呼び出せる
     micropost = current_user.microposts.create!(micropost_params)
     if micropost.save
       render json: micropost, serializer: MicropostSerializer
@@ -20,6 +22,7 @@ class Api::MicropostsController < ApiController
   end
 
   def show
+    # findの場合だと存在しない場合ActiveRecord::RecordNotFound例外が発生する。
     micropost = Micropost.find_by(id: params[:id])
     if micropost
       render json: micropost, serializer: MicropostSerializer

--- a/app/controllers/api/microposts_controller.rb
+++ b/app/controllers/api/microposts_controller.rb
@@ -13,6 +13,13 @@ class Api::MicropostsController < ApiController
   end
 
   def show
+    micropost = Micropost.find_by(id: params[:id])
+    if micropost
+      render json: micropost, serializer: MicropostSerializer
+    else
+      error_message = { error: { messages: [ "404 Not found" ] } }
+      render json: error_message, status: 404
+    end
   end
 
   def index

--- a/app/controllers/api/microposts_controller.rb
+++ b/app/controllers/api/microposts_controller.rb
@@ -36,6 +36,9 @@ class Api::MicropostsController < ApiController
   end
 
   def destroy
+    micropost = current_user.microposts.find(params[:id])
+    micropost.destroy!()
+    render json: micropost, serializer: MicropostSerializer
   end
 
   private

--- a/app/controllers/api/microposts_controller.rb
+++ b/app/controllers/api/microposts_controller.rb
@@ -34,7 +34,7 @@ class Api::MicropostsController < ApiController
 
   def destroy
     micropost = current_user.microposts.find(params[:id])
-    micropost.destroy!()
+    micropost.destroy!
     render json: micropost, serializer: MicropostSerializer
   end
 

--- a/app/controllers/api/microposts_controller.rb
+++ b/app/controllers/api/microposts_controller.rb
@@ -29,8 +29,10 @@ class Api::MicropostsController < ApiController
     end
   end
 
-
   def update
+    micropost = current_user.microposts.find(params[:id])
+    micropost.update!(micropost_params)
+    render json: micropost, serializer: MicropostSerializer
   end
 
   def destroy

--- a/app/controllers/api/microposts_controller.rb
+++ b/app/controllers/api/microposts_controller.rb
@@ -12,24 +12,18 @@ class Api::MicropostsController < ApiController
   def create
     # current_userはUser.findの結果を返すので、
     # modelでhas_manyを指定しているmicropostsを呼び出せる
+    # craeteは返り値としてtrue/falseを返却する
+    # create!は作成したインスタンスを返却する
+    # create!は正常に処理が行なわれなかった場合、例外を発生させる
     micropost = current_user.microposts.create!(micropost_params)
-    if micropost.save
-      render json: micropost, serializer: MicropostSerializer
-    else
-      error_message = { error: { messages: [ "Content can't be blank" ] } }
-      render json: error_message, status: 422
-    end
+    render json: micropost, serializer: MicropostSerializer
   end
 
   def show
-    # findの場合だと存在しない場合ActiveRecord::RecordNotFound例外が発生する。
-    micropost = Micropost.find_by(id: params[:id])
-    if micropost
-      render json: micropost, serializer: MicropostSerializer
-    else
-      error_message = { error: { messages: [ "404 Not found" ] } }
-      render json: error_message, status: 404
-    end
+    # findは存在しない場合ActiveRecord::RecordNotFound例外が発生する。
+    # 親コントローラーが例外をキャッチし、404例外処理を行う
+    micropost = Micropost.find(params[:id])
+    render json: micropost, serializer: MicropostSerializer
   end
 
   def update

--- a/app/controllers/api/microposts_controller.rb
+++ b/app/controllers/api/microposts_controller.rb
@@ -1,6 +1,6 @@
 class Api::MicropostsController < ApiController
   # ログインしたユーザーのみ操作させたいため
-  before_action :authenticate, only: [:create]
+  before_action :authenticate, only: [:create, :update, :destroy]
 
   def index
     # N+1問題を避けるためにincludesを使用する

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -1,7 +1,7 @@
 class ApiController < ActionController::API
   # APIのControllerは、このAPIControllerを継承すること
   def authenticate
-    render json: { errors: "Unauthorized" }, status: 401 unless current_user
+    render json: { error: { messages: ["Unauthorized"] } }, status: 401 unless current_user
   end
 
   def current_user

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -5,6 +5,6 @@ class ApiController < ActionController::API
   end
 
   def current_user
-    @current_user ||= Jwt::UserAuthenticator.(request.headers)
+    @current_user ||= Jwt::UserAuthenticator.call(request.headers)
   end
 end

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -1,10 +1,42 @@
-class ApiController < ActionController::API
+class ApiController < ActionController::Base
   # APIのControllerは、このAPIControllerを継承すること
+
+  # Railsは自動的にCSRF対策のためのtoken検証を行ってくれるが、
+  # APIの場合はステートレスなため不要であり、外部からAPIを利用したいため
+  # CSRF検証に失敗した場合はセッションを空にする指定を行う(初期値の場合は例外を発生させる)
+  protect_from_forgery with: :null_session
+
+  # 独自エラークラスを定義
+  class AuthenticationError < StandardError; end
+
+  # 指定したexceptionが発生した場合の動作を指定
+  # このコントローラーを継承した各コントローラの例外をここでキャッチする。
+
+  # DBにデータが存在しない場合
+  rescue_from ActiveRecord::RecordNotFound, with: :render_404
+  # modelで定義したvalidateに失敗した場合
+  rescue_from ActiveRecord::RecordInvalid, with: :render_422
+  # 認証情報がない状態で認証情報が必要な処理をしようとした場合
+  rescue_from AuthenticationError, with: :not_authenticated
+
   def authenticate
-    render json: { error: { messages: ["Unauthorized"] } }, status: 401 unless current_user
+    raise AuthenticationError unless current_user
   end
 
   def current_user
     @current_user ||= Jwt::UserAuthenticator.call(request.headers)
   end
+
+  private
+    def render_404(exception)
+      render json: { error: { messages: exception.message } }, status: :not_found
+    end
+
+    def render_422(exception)
+      render json: { error: { messages: exception.record.errors.full_messages } }, status: :unprocessable_entity
+    end
+
+    def not_authenticated
+      render json: { error: { messages: ["ログインしてください"] } }, status: :unauthorized
+    end
 end

--- a/app/models/micropost.rb
+++ b/app/models/micropost.rb
@@ -1,0 +1,3 @@
+class Micropost < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/micropost.rb
+++ b/app/models/micropost.rb
@@ -1,3 +1,6 @@
 class Micropost < ApplicationRecord
   belongs_to :user
+  # 登録・更新時にcontentに対して検証を行う
+  # 値が空でないこと、140文字以内であること
+  validates :content, presence: true, length: { maximum: 140 }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,4 +4,5 @@ class User < ApplicationRecord
   validates :name, presence: true
   validates :email, presence: true, uniqueness: true
   validates :password_digest, presence: true
+  has_many :microposts, dependent: :destroy
 end

--- a/app/serializers/micropost_serializer.rb
+++ b/app/serializers/micropost_serializer.rb
@@ -1,4 +1,6 @@
 class MicropostSerializer < ActiveModel::Serializer
   # JSONで返却するカラムを指定
   attributes :id, :content, :created_at, :updated_at, :user
+  # レスポンス内の項目をuser_serializerで定義した項目を返却するようにする
+  belongs_to :user
 end

--- a/app/serializers/micropost_serializer.rb
+++ b/app/serializers/micropost_serializer.rb
@@ -1,0 +1,4 @@
+class MicropostSerializer < ActiveModel::Serializer
+  # JSONで返却するカラムを指定
+  attributes :id, :content, :created_at, :updated_at, :user
+end

--- a/app/services/jwt/token_decryptor.rb
+++ b/app/services/jwt/token_decryptor.rb
@@ -13,4 +13,4 @@ module Jwt::TokenDecryptor
     end
 end
 
-class InvalidTokenError < StandardError end
+class InvalidTokenError < StandardError; end

--- a/app/services/jwt/user_authenticator.rb
+++ b/app/services/jwt/user_authenticator.rb
@@ -5,7 +5,7 @@ module Jwt::UserAuthenticator
     @request_headers = request_headers
 
     begin
-      payload, _header = Jwt::TokenDecryptor.(token)
+      payload, _header = Jwt::TokenDecryptor.call(token)
       User.find(payload["user_id"])
     rescue => e
       # log error here

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,5 +5,6 @@ Rails.application.routes.draw do
     # 今回はcreateのみ使用したいのでonlyオプションで指定する
     resources :users, only: [:create]
     resource :session, only: [:create]
+    resources :microposts, only: [:create, :show, :index, :udpate, :destroy]
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,6 @@ Rails.application.routes.draw do
     # 今回はcreateのみ使用したいのでonlyオプションで指定する
     resources :users, only: [:create]
     resource :session, only: [:create]
-    resources :microposts, only: [:create, :show, :index, :udpate, :destroy]
+    resources :microposts, only: [:create, :show, :index, :update, :destroy]
   end
 end

--- a/db/migrate/20201201151505_create_microposts.rb
+++ b/db/migrate/20201201151505_create_microposts.rb
@@ -1,0 +1,10 @@
+class CreateMicroposts < ActiveRecord::Migration[6.0]
+  def change
+    create_table :microposts do |t|
+      t.text :content
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20201201151505_create_microposts.rb
+++ b/db/migrate/20201201151505_create_microposts.rb
@@ -1,7 +1,7 @@
 class CreateMicroposts < ActiveRecord::Migration[6.0]
   def change
     create_table :microposts do |t|
-      t.text :content
+      t.text :content, null: false
       t.references :user, null: false, foreign_key: true
 
       t.timestamps

--- a/db/migrate/20201213175551_change_columns_add_notnull_on_microposts.rb
+++ b/db/migrate/20201213175551_change_columns_add_notnull_on_microposts.rb
@@ -1,0 +1,5 @@
+class ChangeColumnsAddNotnullOnMicroposts < ActiveRecord::Migration[6.0]
+  def change
+    change_column_null :microposts, :content, false
+  end
+end

--- a/db/migrate/20201213175551_change_columns_add_notnull_on_microposts.rb
+++ b/db/migrate/20201213175551_change_columns_add_notnull_on_microposts.rb
@@ -1,5 +1,0 @@
-class ChangeColumnsAddNotnullOnMicroposts < ActiveRecord::Migration[6.0]
-  def change
-    change_column_null :microposts, :content, false
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_19_080059) do
+ActiveRecord::Schema.define(version: 2020_12_01_151505) do
+
+  create_table "microposts", force: :cascade do |t|
+    t.text "content"
+    t.integer "user_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_microposts_on_user_id"
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "name", null: false
@@ -21,4 +29,5 @@ ActiveRecord::Schema.define(version: 2020_07_19_080059) do
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
+  add_foreign_key "microposts", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_13_175551) do
+ActiveRecord::Schema.define(version: 2020_12_01_151505) do
 
   create_table "microposts", force: :cascade do |t|
     t.text "content", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_01_151505) do
+ActiveRecord::Schema.define(version: 2020_12_13_175551) do
 
   create_table "microposts", force: :cascade do |t|
-    t.text "content"
+    t.text "content", null: false
     t.integer "user_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false

--- a/spec/factories/microposts.rb
+++ b/spec/factories/microposts.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :micropost do
+    content { "MyText" }
+    user
+  end
+end

--- a/spec/requests/api/microposts_request_spec.rb
+++ b/spec/requests/api/microposts_request_spec.rb
@@ -1,0 +1,134 @@
+require "rails_helper"
+
+RSpec.describe "Api::Microposts", type: :request do
+  describe "GET /api/microposts" do
+    let!(:microposts) { create_list(:micropost, 5) }
+    it "マイクロポストの一覧が取得できること" do
+      get api_microposts_path
+      expect(response).to have_http_status(200)
+      json = JSON.parse(response.body)
+      expect(json["microposts"]).to match_array(microposts.map { |micropost|
+        include(
+          "id" => micropost.id,
+          "content" => micropost.content,
+          "created_at"=> be_present,
+          "updated_at"=> be_present,
+          "user" => include("id" => micropost.user.id)
+        )
+      })
+    end
+  end
+
+  describe "POST /api/microposts" do
+    let(:user) { create(:user) }
+    let(:token) { Jwt::TokenProvider.call(user_id: user.id) }
+    let(:headers) { { Authorization: "Bearer #{token}" } }
+    let(:micropost_params) { { micropost: { content: "hoge" } } }
+    context "ログイン済みの場合" do
+      it "マイクロポストが作成できること" do
+        post api_microposts_path, params: micropost_params, headers: headers
+        expect(response).to have_http_status(200)
+        json = JSON.parse(response.body)
+        expect(json["micropost"]).to include({
+                                                 "id" => be_present,
+                                                 "content" => "hoge",
+                                                 "created_at"=> be_present,
+                                                 "updated_at"=> be_present,
+                                                 "user" => include("id" => user.id)
+                                             })
+      end
+    end
+
+    context "ログインしていない場合" do
+      it "401エラーになること" do
+        post api_microposts_path, params: micropost_params
+        expect(response).to have_http_status(401)
+        json = JSON.parse(response.body)
+        expect(json["error"]).to include({
+                                             "messages" => be_present
+                                         })
+      end
+    end
+  end
+
+  describe "GET /api/microposts/:id" do
+    let(:micropost) { create(:micropost) }
+    it "マイクロポストの詳細を取得できること" do
+      get api_micropost_path(micropost)
+      expect(response).to have_http_status(200)
+      json = JSON.parse(response.body)
+      expect(json["micropost"]).to include({
+                                               "id" => micropost.id,
+                                               "content" => micropost.content,
+                                               "created_at"=> be_present,
+                                               "updated_at"=> be_present,
+                                               "user" => include("id" => micropost.user.id)
+                                           })
+    end
+  end
+
+  describe "PATCH /api/microposts/:id" do
+    let(:user) { create(:user) }
+    let(:token) { Jwt::TokenProvider.call(user_id: user.id) }
+    let(:headers) { { Authorization: "Bearer #{token}" } }
+    let(:micropost) { create(:micropost, user: user) }
+    let(:micropost_params) { { micropost: { content: "hoge" } } }
+    context "ログイン済みの場合" do
+      it "マイクロポストが更新できること" do
+        patch api_micropost_path(micropost), params: micropost_params, headers: headers
+        expect(response).to have_http_status(200)
+        json = JSON.parse(response.body)
+        expect(json["micropost"]).to include({
+                                                 "id" => be_present,
+                                                 "content" => "hoge",
+                                                 "created_at"=> be_present,
+                                                 "updated_at"=> be_present,
+                                                 "user" => include("id" => user.id)
+                                             })
+      end
+    end
+
+    context "ログインしていない場合" do
+      it "401エラーになること" do
+        patch api_micropost_path(micropost), params: micropost_params
+        expect(response).to have_http_status(401)
+        json = JSON.parse(response.body)
+        expect(json["error"]).to include({
+                                             "messages" => be_present
+                                         })
+      end
+    end
+  end
+
+  describe "DELETE /api/microposts/:id" do
+    let(:user) { create(:user) }
+    let(:token) { Jwt::TokenProvider.call(user_id: user.id) }
+    let(:headers) { { Authorization: "Bearer #{token}" } }
+    let(:micropost) { create(:micropost, user: user) }
+    context "ログイン済みの場合" do
+      it "マイクロポストが削除できること" do
+        delete api_micropost_path(micropost), headers: headers
+        expect(response).to have_http_status(200)
+        json = JSON.parse(response.body)
+        expect(json["micropost"]).to include({
+                                                 "id" => be_present,
+                                                 "content" => micropost.content,
+                                                 "created_at"=> be_present,
+                                                 "updated_at"=> be_present,
+                                                 "user" => include("id" => user.id)
+                                             })
+      end
+    end
+
+    context "ログインしていない場合" do
+      it "401エラーになること" do
+        delete api_micropost_path(micropost)
+        expect(response).to have_http_status(401)
+        json = JSON.parse(response.body)
+        expect(json["error"]).to include({
+                                             "messages" => be_present
+                                         })
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要

* micropostsのCRUD作成
* ログイン済ユーザーのみ操作を行える処理の追加

## 確認方法

1. `git clone -b feature/02_login_front https://github.com/tomoki-akatsu/rails-api.git`のコマンドでGitHubからCloneしてください
2. `bundle install --path vendor/bundle` を実行してください
3. `bundle exec rails db:create`を実行し、DBを作成してください
4. `bundle exec rails db:migrate` を実行してください

## コメント

services/jwt内の処理を確認して、どうしてcurrent_user.micropostsという宣言が可能なのかを把握するのに時間がかかりました....